### PR TITLE
Add timer argument to profileit decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ keyword argument timer.  For example to use wall time instead of CPU time you mi
     @profileit(_logger, timer=time.time)
 
 Your value of timer, if not None or omitted, is passed to the cProfile.Profile()
-constructor as keyword argument timer.  If you omit it, the keywrod argument is not passed
+constructor as keyword argument timer.  If you omit it, the keyword argument is not passed
 through to Profile().
 
 For more information on timers, see the [Python profiling documentation] [4]

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ using [pyprof2calltree] [3] to convert the files to a format it understands.
 
     pyprof2calltree -i /tmp/openerp-profile-1371906027.910166-Thread-16.profile -k
 
+
+--------------------------------
+
+You can specify an alternative timer function to the decorator, using the optional
+keyword argument timer.  For example to use wall time instead of CPU time you might do:
+
+    import time
+
+    # ...
+    @profileit(_logger, timer=time.time)
+
+Your value of timer, if not None or omitted, is passed to the cProfile.Profile()
+constructor as keyword argument timer.  If you omit it, the keywrod argument is not passed
+through to Profile().
+
+For more information on timers, see the [Python profiling documentation] [4]
+
 --------------------------------
 
 Note:  This code has been used with OpenERP 6.1.  I imagine 
@@ -73,3 +90,4 @@ This decorator is based on an [answer] [1] on stackoverflow.
 [1]: http://stackoverflow.com/questions/5375624/a-decorator-that-profiles-a-method-call-and-logs-the-profiling-result "Stackoverflow answer"
 [2]: http://kcachegrind.sourceforge.net/html/Home.html "KCachegrind"
 [3]: https://pypi.python.org/pypi/pyprof2calltree/ "pyprof2calltree"
+[4]: https://docs.python.org/2/library/profile.html "26.4. The Python Profilers"

--- a/openerpprofiledecorator.py
+++ b/openerpprofiledecorator.py
@@ -5,7 +5,7 @@ import threading
 import time
 import os
 
-def profileit(log):
+def profileit(log, timer=None):
     """
     A quick profiling decorator designed to work with OpenERP
     and it's logging.
@@ -53,7 +53,12 @@ def profileit(log):
 
     def inner(func):
         def wrapper(*args, **kwargs):
-            prof = cProfile.Profile()
+            prof_kws = {}
+            if timer is not None:
+                # Note passing None to timer results in TypeError "NoneType object is not callable" warnings
+                # hence use of prof_kws dictionary
+                prof_kws['timer'] = timer
+            prof = cProfile.Profile(**prof_kws)
             retval = prof.runcall(func, *args, **kwargs)
             fname = valid_filename()
             prof.dump_stats(fname)


### PR DESCRIPTION
This will allow use of other timer functions than the default, for example to use wall time instead of CPU time.
